### PR TITLE
Add expense type clean_up_items_expenses

### DIFF
--- a/dsnap_rules/validate.py
+++ b/dsnap_rules/validate.py
@@ -30,6 +30,8 @@ SCHEMA = {
                     "type": "number", "minimum": 0},
                 "fuel_for_primary_heating_source": {
                     "type": "number", "minimum": 0},
+                "clean_up_items_expenses": {
+                    "type": "number", "minimum": 0},
                 "disaster_damaged_vehicle_expenses": {
                     "type": "number", "minimum": 0},
                 "storage_expenses": {


### PR DESCRIPTION
This was inadvertently missed when the disaster expenses were broken up
by type.